### PR TITLE
:art: Simplify select overloads for words

### DIFF
--- a/libvast/vast/word.hpp
+++ b/libvast/vast/word.hpp
@@ -422,34 +422,26 @@ static constexpr auto find_prev(T x, detail::word_size_type<T> i)
 template <bool Bit = true, class T>
 static constexpr auto select(T x, detail::word_size_type<T> i)
 -> std::enable_if_t<
-  Bit && detail::is_unsigned_integral_v<T>,
+  detail::is_unsigned_integral_v<T>,
   detail::word_size_type<T>
 > {
   // TODO: make this efficient and branch-free. There is one implementation
   // that counts from the right for 64-bit here:
   // http://graphics.stanford.edu/~seander/bithacks.html
+  const auto pred = [](const auto&... args){
+    if constexpr(Bit) {
+      return word<T>::test(args...);
+    }
+    else {
+      return !word<T>::test(args...);
+    }
+  };
   auto cum = 0u;
   for (auto j = 0u; j < word<T>::width; ++j)
-    if (word<T>::test(x, j))
+    if (pred(x, j))
       if (++cum == i)
         return j;
   return word<T>::npos;
 }
-
-template <bool Bit, class T>
-static constexpr auto select(T x, detail::word_size_type<T> i)
--> std::enable_if_t<
-  !Bit && detail::is_unsigned_integral_v<T>,
-  detail::word_size_type<T>
-> {
-  // TODO: see note above.
-  auto cum = 0u;
-  for (auto j = 0u; j < word<T>::width; ++j)
-    if (!word<T>::test(x, j))
-      if (++cum == i)
-        return j;
-  return word<T>::npos;
-}
-
 } // namespace vast
 


### PR DESCRIPTION
Problem:
- The overloads for `select` on words is not very DRY. Each function
  template is similar except for the predicate tested.

Solution:
- Remove additional overload and SFINAE in favor of `if-constexpr` to
  select the right predicate to use.

###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
